### PR TITLE
Fix: Openweather API URL

### DIFF
--- a/TerminalWidget.js
+++ b/TerminalWidget.js
@@ -222,7 +222,7 @@ async function fetchWeather() {
   if (!location) {
     location = DEFAULT_LOCATION;
   }
-  const url = "https://api.openweathermap.org/data/2.5/onecall?lat=" + location.latitude + "&lon=" + location.longitude + "&exclude=minutely,hourly,alerts&units=imperial&lang=en&appid=" + WEATHER_API_KEY;
+  const url = "https://api.openweathermap.org/data/3.0/onecall?lat=" + location.latitude + "&lon=" + location.longitude + "&exclude=minutely,hourly,alerts&units=imperial&lang=en&appid=" + WEATHER_API_KEY;
   const address = await Location.reverseGeocode(location.latitude, location.longitude);
   const data = await fetchJson(url);
 


### PR DESCRIPTION
The Openweather API URL is out-of-date, and requires a call to 3.0 to function

The 2.5 call always seems to result in `Error 401`, which indicates a failure to call the API, but a 3.0 call will succeed